### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ A tool for getting the latest assets from CircleCI.
       --accept-failed      Accepts artifacts from the latest build
       --build BUILD        Go to a specific build
 
-.. |Latest Version| image:: https://pypip.in/version/circle_asset/badge.svg
+.. |Latest Version| image:: https://img.shields.io/pypi/v/circle_asset.svg
    :target: https://pypi.python.org/pypi/circle-asset/
 .. |Circle CI| image:: https://circleci.com/gh/prophile/circle-asset.svg?style=svg
    :target: https://circleci.com/gh/prophile/circle-asset


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20circle-asset))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `circle-asset`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.